### PR TITLE
Add an option to list running Moxide sessions

### DIFF
--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -20,4 +20,8 @@ pub struct ListCli {
     /// Show all templates including hidden ones
     #[arg(short, long, default_value_t = false)]
     pub all: bool,
+
+    /// Show running Moxide sessions
+    #[arg(short, long, default_value_t = false)]
+    pub running: bool,
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,9 +1,15 @@
-use crate::{cli::list::ListCli, directories, helpers::format_name, projects, templates};
+use crate::{cli::list::ListCli, directories, helpers::format_name, projects, templates, tmux::session_exists};
 
 pub fn list_handler(args: ListCli) {
-    let projects = projects::parse_project_config();
-    let templates = templates::parse_template_config();
-    let dirs = directories::parse_directory_config();
+    let mut projects = projects::parse_project_config();
+    let mut templates = templates::parse_template_config();
+    let mut dirs = directories::parse_directory_config();
+
+    if args.running {
+        projects.retain(|project| session_exists(&project.name).unwrap_or(false));
+        templates.retain(|template| session_exists(&template.name).unwrap_or(false));
+        dirs.retain(|dir| session_exists(dir.get_name()).unwrap_or(false));
+    }
 
     for project in projects {
         println!(


### PR DESCRIPTION
Hi,
I added an option `running` to the `list` command to only show the moxide sessions that are running. I don't know if the name is the most appropriate. I went with `active` first, but the short `a` collided with the `all` option.

As these are my first lines of Rust, I don't know if it follows the coding standards or if there is further documentation to update. Same with Nix, I don't know the impact of the change, even if I think there is none.

 I find the feature useful for bash scripts, like the one presented in the README. The following one lists all sessions, running ones presented first with a suffix to show that it's running.

```bash
#!/usr/bin/env bash

project_prefix="🚀"
template_prefix="🛠️"
directory_prefix="📁"
running_suffix="~"

sessions=$(moxide list \
    --format-project "$project_prefix {}" \
    --format-template "$template_prefix {}" \
    --format-directory "$directory_prefix {}"
)

running_sessions=$(moxide list --running \
    --format-project "$project_prefix {}" \
    --format-template "$template_prefix {}" \
    --format-directory "$directory_prefix {}"
)

inactive_sessions=$(grep -Fxvf  <(echo "$running_sessions") <(echo "$sessions"))

running_sessions=$(moxide list --running \
    --format-project "$project_prefix {} $running_suffix" \
    --format-template "$template_prefix {} $running_suffix" \
    --format-directory "$directory_prefix {} $running_suffix"
)

value=$(
    echo -e "$running_sessions\n$inactive_sessions" |
        fzf \
            --height 13 \
            --tmux 30% \
            --no-sort \
            --layout reverse \
            --border rounded \
            --border-label "Moxide Sessions" \
            --no-scrollbar
)

IFS=' ' read -r prefix name running <<<"$value"
case "$prefix" in
$project_prefix)
    moxide project start "$name"
    ;;
$template_prefix)
    moxide template start "$name"
    ;;
$directory_prefix)
    moxide dir start "$name"
    ;;
esac
```